### PR TITLE
Convert OneSky languageCode to be compatible with Symfony2 translation bundle.

### DIFF
--- a/src/Adapter/OneSkyAdapter.php
+++ b/src/Adapter/OneSkyAdapter.php
@@ -72,9 +72,33 @@ class OneSkyAdapter extends TranslationAdapter
         $this->dumpToYaml($english, $phraseCollectionKey, 'en');
 
         foreach ($collection['data']['translations'] as $key => $values) {
-            $this->dumpToYaml($values, $phraseCollectionKey, $key);
+            $languageTag = $this->convertToSymfonyLanguageTag($key);
+            $this->dumpToYaml($values, $phraseCollectionKey, $languageTag);
         }
     }
+
+
+    /**
+    +     * This method converts a language code provided by OneSky into Symfony 2 language code format.
+    +     * e.g: pt-PT -> pt_PT
+    +     *
+    +     * View more details about language tag here: http://en.wikipedia.org/wiki/IETF_language_tag
+    +     *
+    +     * @param $languageString
+    +     * @return string
+    +     */
+    public function convertToSymfonyLanguageTag($languageString)
+    {
+        $languageParts = explode('-', $languageString);
+        $countryCode = $languageParts[0];
+        $languageTag = $countryCode;
+        if(count($languageParts) > 1) {
+            $languageTag .= '_'.$languageParts[1];
+        }
+
+        return $languageTag;
+    }
+
 
     private function dumpToYaml($phrases, $phraseCollectionKey, $locale)
     {

--- a/src/Tests/Unit/Adapter/OneSkyAdapterTest.php
+++ b/src/Tests/Unit/Adapter/OneSkyAdapterTest.php
@@ -12,6 +12,8 @@ class OneSkyAdapterTest extends \PHPUnit_Framework_TestCase
 {
     protected $kernel;
     protected $container;
+    /** @var  \Partnermarketing\TranslationBundle\Adapter\OneSkyAdapter $adapter */
+    protected $adapter;
 
     public function setUp()
     {
@@ -87,5 +89,17 @@ class OneSkyAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $phraseCollections);
         $this->assertEquals('Bunnies for Dummies', $phraseCollections['books']['book_1.title']['string']);
         $this->assertEquals('10 Best Movies', $phraseCollections['pages/movies']['page_title']['string']);
+    }
+
+    public function testConvertToSymfonyLanguageTag()
+    {
+        $languageTag = 'pt-PT';
+        $symfonyLanguageTag = $this->adapter->convertToSymfonyLanguageTag($languageTag);
+        $this->assertEquals('pt_PT', $symfonyLanguageTag);
+
+        // Ensure it works with simple language tags.
+        $languageTag = 'pt';
+        $symfonyLanguageTag = $this->adapter->convertToSymfonyLanguageTag($languageTag);
+        $this->assertEquals('pt', $symfonyLanguageTag);
     }
 }


### PR DESCRIPTION
e.g  `pt-PT` to `pt_pt` .
