### PR TITLE
Use symfony 2 param locale instead of base_language.

### DIFF
--- a/etc/parameters.yml.sample
+++ b/etc/parameters.yml.sample
@@ -1,9 +1,10 @@
 parameters:
+    locale: en_GB
     partnermarketing_translation:
-        base_language: en_GB
+        base_language: %locale%
         supported_languages:
             # To add a language, add the key returned by PHP's 'Locale::getDisplayLanguages()'.
-            - en
+            - %locale%
         one_sky:
             project_id: xxx
             api_key:    xxx

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,12 +18,21 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
+
         $rootNode = $treeBuilder->root('partnermarketing_translation');
 
         $rootNode
             ->children()
-                ->variableNode('supported_languages')->isRequired()->end()
-                ->variableNode('base_language')->isRequired()->end()
+                ->variableNode('base_language')
+                    ->isRequired()
+                    ->defaultValue('%locale%')
+                ->end()
+                ->arrayNode('supported_languages')
+                    ->isRequired()
+                    ->prototype('scalar')
+                        ->defaultValue('%locale%')
+                    ->end()
+                ->end()
                 ->arrayNode('one_sky')
                     ->children()
                         ->scalarNode('project_id')

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -1,6 +1,6 @@
 partnermarketing_translation:
-    supported_languages: %partnermarketing_translation.supported_languages%
     base_language: %partnermarketing_translation.base_language%
+    supported_languages: %partnermarketing_translation.supported_languages%
     one_sky:
         project_id: %partnermarketing_translation.one_sky.project_id%
         api_key:    %partnermarketing_translation.one_sky.api_key%

--- a/src/Tests/Application/config.yml
+++ b/src/Tests/Application/config.yml
@@ -1,10 +1,11 @@
 parameters:
     kernel.secret: 123
     debug.error_handler.throw_at: a
+    locale: en_GB
 
 partnermarketing_translation:
-    supported_languages: [en]
-    base_language: en_GB
+    base_language: %locale%
+    supported_languages: [%locale%]
     one_sky:
         project_id: 111
         api_key: 222

--- a/src/Tests/Unit/DependencyInjection/PartnermarketingTranslationExtensionTest.php
+++ b/src/Tests/Unit/DependencyInjection/PartnermarketingTranslationExtensionTest.php
@@ -30,8 +30,8 @@ class PartnermarketingTranslationExtensionTest extends \PHPUnit_Framework_TestCa
     public function testGetConfigParamsExist()
     {
         $configs = array(
-            "supported_languages" => null,
             "base_language" => 'en_GB',
+            "supported_languages" => ['en_GB'],
             "one_sky"             => array(
                 "project_id" => "123",
                 "api_key"    => "xxx",
@@ -52,8 +52,8 @@ class PartnermarketingTranslationExtensionTest extends \PHPUnit_Framework_TestCa
     public function testGetConfigWithOverrideValues()
     {
         $configs = array(
-                "supported_languages" => null,
                 "base_language" => 'en_GB',
+                "supported_languages" => ['en_GB'],
                 "one_sky" => array(
                     "project_id" => "123",
                     "api_key" => "xxx",
@@ -65,11 +65,12 @@ class PartnermarketingTranslationExtensionTest extends \PHPUnit_Framework_TestCa
         $this->extension->load(array($configs), $container = $this->getContainer());
 
         $this->assertEquals('en_GB', $container->getParameter($this->root . ".base_language"));
-        $this->assertEquals(null, $container->getParameter($this->root . ".supported_languages"));
+        $this->assertEquals(['en_GB'], $container->getParameter($this->root . ".supported_languages"));
         $this->assertEquals('123', $container->getParameter($this->root . ".one_sky.project_id"));
         $this->assertEquals('xxx', $container->getParameter($this->root . ".one_sky.api_key"));
         $this->assertEquals('xxx', $container->getParameter($this->root . ".one_sky.api_secret"));
     }
+
 
     /**
      * @return PartnermarketingTranslationExtension


### PR DESCRIPTION
- [x] use symfony 2 project locale as default value for base_language.