### PR TITLE
Workaround different yaml versions.

### DIFF
--- a/src/Adapter/OneSkyAdapter.php
+++ b/src/Adapter/OneSkyAdapter.php
@@ -103,6 +103,8 @@ class OneSkyAdapter extends TranslationAdapter
                     $result = array_merge($existingContent, $yamlArray);
 
                     $yaml = YamlParser::dump($result, 4);
+                    $yaml = $this->keepQuotesOnBooleanValue($yaml);
+
                     file_put_contents($filePath, $yaml);
                 }
             }
@@ -144,7 +146,29 @@ class OneSkyAdapter extends TranslationAdapter
         }
 
         $yaml = YamlParser::dump($phrases, 4);
+        $yaml = $this->keepQuotesOnBooleanValue($yaml);
+
         file_put_contents($targetFile, $yaml);
+    }
+
+    /**
+     * Workaround to ensure that [Yes, No] values keep the quotes ' around.
+     * This needs to happen for those words because OneSky is using YAML 1.1 spec and
+     * Yes is interpreted as true, so they will return true on next translations pull.
+     *
+     * YAML 1.1 spec for boolean: http://yaml.org/type/bool.html
+     * YAML 1.2 spec fot boolean: http://www.yaml.org/spec/1.2/spec.html#id2803629
+     *
+     * @param $yamlString
+     *
+     * @return mixed
+     */
+    private function keepQuotesOnBooleanValue($yamlString)
+    {
+        $yaml = preg_replace('/: (\byes\b)/i', "': "."$1"."'", $yamlString);
+        $yaml = preg_replace('/: (\bno\b)/i', "': "."$1"."'", $yaml);
+
+        return $yaml;
     }
 
 

--- a/src/Adapter/OneSkyAdapter.php
+++ b/src/Adapter/OneSkyAdapter.php
@@ -165,8 +165,10 @@ class OneSkyAdapter extends TranslationAdapter
      */
     private function keepQuotesOnBooleanValue($yamlString)
     {
-        $yaml = preg_replace('/: (\byes\b)/i', "': "."$1"."'", $yamlString);
-        $yaml = preg_replace('/: (\bno\b)/i', "': "."$1"."'", $yaml);
+        $yaml = preg_replace('/: (\byes\b)/i', ": '"."$1"."'", $yamlString);
+        $yaml = preg_replace('/: (\bno\b)/i', ": '"."$1"."'", $yaml);
+        $yaml = preg_replace('/: (\bon\b)/i', ": '"."$1"."'", $yaml);
+        $yaml = preg_replace('/: (\boff\b)/i', ": '"."$1"."'", $yaml);
 
         return $yaml;
     }

--- a/src/Tests/Unit/Adapter/OneSkyAdapterTest.php
+++ b/src/Tests/Unit/Adapter/OneSkyAdapterTest.php
@@ -269,6 +269,10 @@ inactive_test: No # comments are removed by yaml parser/dumper.
 notes: "Notes"
 no_more: "No more"
 more_no: "more No"
+active_a: On
+inactive_a: Off
+active_b: "On"
+inactive_b: "Off"
 ');
         $this->adapter->setSupportedLanguages(['pt_PT']);
         $this->adapter->setClient($oneSkyMockClient);
@@ -283,6 +287,10 @@ inactive_test: 'No'
 notes: Notes
 no_more: 'No more'
 more_no: 'more No'
+active_a: 'On'
+inactive_a: 'Off'
+active_b: 'On'
+inactive_b: 'Off'
 ";
         $this->assertEquals($expectedOutput, $existingContent);
 


### PR DESCRIPTION
OneSky looks like is using YAML 1.1 so when we send a string like 'Yes' without quotes they convert it to `true`.

To avoid that we need to keep quotes on translations values like `Yes`, `No`.

- [x] Ensure quotes are kept for `Yes` translation value.
- [x] Ensure quotes are kept for `No` translation value.
- [x] Ensure quotes are kept for `On` translation value.
- [x] Ensure quotes are kept for `Off` translation value.